### PR TITLE
[Feat] 예약자 확인 및 승인처리 카드 컴포넌트

### DIFF
--- a/components/commons/card/ApplicantManager.tsx
+++ b/components/commons/card/ApplicantManager.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useState } from 'react';
 
 interface BookerInformation {

--- a/components/commons/card/ApplicantManager.tsx
+++ b/components/commons/card/ApplicantManager.tsx
@@ -59,7 +59,7 @@ const ApplicantManager = ({
           </>
         ) : reservationStatus === 'confirmed' ? (
           <p className="w-[82px] h-[38px] bg-[#FFF4E8] rounded-[26.5px] px-3 py-2 text-[#FF7C1D] text-sm font-bold cursor-default">
-            예약확정
+            예약승인
           </p>
         ) : (
           <p className="w-[82px] h-[38px] bg-[#FFE4E0] rounded-[26.5px] px-3 py-2 text-[#FF472E] text-sm font-bold cursor-default">

--- a/components/commons/card/ApplicantManager.tsx
+++ b/components/commons/card/ApplicantManager.tsx
@@ -45,25 +45,25 @@ const ApplicantManager = ({
         {reservationStatus === 'pending' ? (
           <>
             <button
-              className="w-[82px] h-[38px] bg-black200 rounded-md px-3 py-2 text-white text-sm font-bold"
+              className="w-[82px] h-[38px] bg-black200 rounded-md px-3 py-2 text-white text-[14px] font-bold"
               onClick={() => handleReservationStatusChange('confirmed')}
             >
               승인하기
             </button>
             <button
-              className="w-[82px] h-[38px] bg-white border rounded-md px-3 py-2 text-black text-sm font-bold"
+              className="w-[82px] h-[38px] bg-white border rounded-md px-3 py-2 text-black text-[14px] font-bold"
               onClick={() => handleReservationStatusChange('declined')}
             >
               거절하기
             </button>
           </>
         ) : reservationStatus === 'confirmed' ? (
-          <p className="w-[82px] h-[38px] bg-[#FFF4E8] rounded-[26.5px] px-3 py-2 text-[#FF7C1D] text-sm font-bold cursor-default">
-            예약승인
+          <p className="w-[82px] h-[38px] bg-[#FFF4E8] rounded-[26.5px] px-3 py-2 text-[#FF7C1D] text-[14px] font-bold cursor-default flex justify-center">
+            예약 승인
           </p>
         ) : (
-          <p className="w-[82px] h-[38px] bg-[#FFE4E0] rounded-[26.5px] px-3 py-2 text-[#FF472E] text-sm font-bold cursor-default">
-            예약거절
+          <p className="w-[82px] h-[38px] bg-[#FFE4E0] rounded-[26.5px] px-3 py-2 text-[#FF472E] text-[14px] font-bold cursor-default flex justify-center">
+            예약 거절
           </p>
         )}
       </div>

--- a/components/commons/card/ApplicantManager.tsx
+++ b/components/commons/card/ApplicantManager.tsx
@@ -58,13 +58,13 @@ const ApplicantManager = ({
             </button>
           </>
         ) : reservationStatus === 'confirmed' ? (
-          <button className="w-[82px] h-[38px] bg-[#FFF4E8] rounded-[26.5px] px-3 py-2 text-[#FF7C1D] text-sm font-bold cursor-default">
+          <p className="w-[82px] h-[38px] bg-[#FFF4E8] rounded-[26.5px] px-3 py-2 text-[#FF7C1D] text-sm font-bold cursor-default">
             예약확정
-          </button>
+          </p>
         ) : (
-          <button className="w-[82px] h-[38px] bg-[#FFE4E0] rounded-[26.5px] px-3 py-2 text-[#FF472E] text-sm font-bold cursor-default">
+          <p className="w-[82px] h-[38px] bg-[#FFE4E0] rounded-[26.5px] px-3 py-2 text-[#FF472E] text-sm font-bold cursor-default">
             예약거절
-          </button>
+          </p>
         )}
       </div>
     </div>

--- a/components/commons/card/ApplicantManager.tsx
+++ b/components/commons/card/ApplicantManager.tsx
@@ -48,7 +48,7 @@ const ApplicantManager = ({
               className="w-[82px] h-[38px] bg-black200 rounded-md px-3 py-2 text-white text-sm font-bold"
               onClick={() => handleReservationStatusChange('confirmed')}
             >
-              확정하기
+              승인하기
             </button>
             <button
               className="w-[82px] h-[38px] bg-white border rounded-md px-3 py-2 text-black text-sm font-bold"

--- a/components/commons/card/ApplicantManager.tsx
+++ b/components/commons/card/ApplicantManager.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+
+interface BookerInformation {
+  nickname: string;
+  headCount: number;
+  status: string;
+  activityId: number;
+  reservationId: number;
+}
+
+/**
+ * 예약 승인여부 확인, 예약 확정 및 거절을 할 수 있는 카드
+ * @param nickname 닉네임
+ * @param headCount 인원
+ * @param status pending(보류), confirmed(확정), declined(거절)
+ * @param activityId 체험Id
+ * @param reservationId 예약Id
+ */
+const ApplicantManager = ({
+  nickname,
+  headCount,
+  status,
+  activityId,
+  reservationId,
+}: BookerInformation) => {
+  const [reservationStatus, SetReservationStatus] = useState(status);
+
+  const handleReservationStatusChange = (status: string) => {
+    SetReservationStatus(status);
+    //TODO : api연동 필요. patch
+    // /4-13/my-activities/{activityId}/reservations/{reservationId}
+  };
+
+  return (
+    <div className="w-[381px] h-[116px] rad rounded-md border border-gray200 p-4 gap-2">
+      <div className="gap-2.5 flex flex-row">
+        <p className="text-gray500">닉네임</p>
+        <p>{nickname}</p>
+      </div>
+      <div className="gap-2.5 flex flex-row">
+        <p className="text-gray500">인원</p>
+        <p>{headCount}명</p>
+      </div>
+      <div className="w-[350px] flex justify-end gap-2">
+        {reservationStatus === 'pending' ? (
+          <>
+            <button
+              className="w-[82px] h-[38px] bg-black200 rounded-md px-3 py-2 text-white text-sm font-bold"
+              onClick={() => handleReservationStatusChange('confirmed')}
+            >
+              확정하기
+            </button>
+            <button
+              className="w-[82px] h-[38px] bg-white border rounded-md px-3 py-2 text-black text-sm font-bold"
+              onClick={() => handleReservationStatusChange('declined')}
+            >
+              거절하기
+            </button>
+          </>
+        ) : reservationStatus === 'confirmed' ? (
+          <button className="w-[82px] h-[38px] bg-[#FFF4E8] rounded-[26.5px] px-3 py-2 text-[#FF7C1D] text-sm font-bold cursor-default">
+            예약확정
+          </button>
+        ) : (
+          <button className="w-[82px] h-[38px] bg-[#FFE4E0] rounded-[26.5px] px-3 py-2 text-[#FF472E] text-sm font-bold cursor-default">
+            예약거절
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ApplicantManager;


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #57

## 📝작업 내용

> 예약자의 이름과 인원을 확인 후 예약확인 및 거절을 진행할 수 있습니다. 

<img width="401" alt="image" src="https://github.com/GlobalNomad-FE/FE/assets/101369040/d625d132-051a-490e-b604-96c39c38f5cc">
<img width="402" alt="image" src="https://github.com/GlobalNomad-FE/FE/assets/101369040/00d4e73c-fb61-434d-9dd1-75940ef0b6ba">
<img width="405" alt="image" src="https://github.com/GlobalNomad-FE/FE/assets/101369040/ba60faad-f5cd-4a7a-929d-9c773153c26a">


## 💬리뷰 요구사항(선택)

>