### PR TITLE
[Feat] 예약 확인현황 캘린더 내 데이터 연결

### DIFF
--- a/apis/my-activitie-reservation-status/keys.ts
+++ b/apis/my-activitie-reservation-status/keys.ts
@@ -1,0 +1,15 @@
+export const reservationsKey = {
+  getMyReservations: (
+    status?: 'pending' | 'confirmed' | 'declined' | 'canceled' | 'completed',
+  ) => ['myReservations', status],
+};
+
+export const myActivitiesKey = {
+  getActivities: (
+    methodValue: number | null, // cursorId 또는 page 값
+    size?: number,
+    category?: string,
+    keyword?: string,
+    sort?: 'most_reviewed' | 'price_asc' | 'price_desc' | 'latest',
+  ) => ['my-activities', methodValue, size, category, keyword, sort],
+};

--- a/apis/my-activitie-reservation-status/keys.ts
+++ b/apis/my-activitie-reservation-status/keys.ts
@@ -13,3 +13,11 @@ export const myActivitiesKey = {
     sort?: 'most_reviewed' | 'price_asc' | 'price_desc' | 'latest',
   ) => ['my-activities', methodValue, size, category, keyword, sort],
 };
+
+export const myReservationStatusKey = {
+  getMyReservationStatus: (
+    activityId?: number,
+    year?: string,
+    month?: string,
+  ) => ['reservation-dashboard', activityId, year, month],
+};

--- a/apis/my-activitie-reservation-status/keys.ts
+++ b/apis/my-activitie-reservation-status/keys.ts
@@ -21,3 +21,18 @@ export const myReservationStatusKey = {
     month?: string,
   ) => ['reservation-dashboard', activityId, year, month],
 };
+
+export const reservedScheduleKey = {
+  getReservedSchedule: (activityId?: number, date?: string) => [
+    'reserved-schedule',
+    activityId,
+    date,
+  ],
+};
+export const reservedTimeKey = {
+  getReservedTime: (
+    activityId: number | undefined,
+    scheduleId: number | undefined,
+    status: string,
+  ) => ['reserved-time', activityId, scheduleId, status],
+};

--- a/apis/my-activitie-reservation-status/useGetMyActivities.ts
+++ b/apis/my-activitie-reservation-status/useGetMyActivities.ts
@@ -67,11 +67,11 @@ async function getActivities(request: GetActivitiesRequest) {
 const useGetMyActivities = (request: GetActivitiesRequest) => {
   return useQuery({
     queryKey: myActivitiesKey.getActivities(
-      // request.method === 'cursor' ? request.cursorId : request.page,
+      request.method === 'cursor' ? request.cursorId : request.page,
       request.size,
-      // request.category,
-      // request.keyword,
-      // request.sort,
+      request.category,
+      request.keyword,
+      request.sort,
     ),
     queryFn: () => getActivities(request),
   });

--- a/apis/my-activitie-reservation-status/useGetMyActivities.ts
+++ b/apis/my-activitie-reservation-status/useGetMyActivities.ts
@@ -1,0 +1,80 @@
+import { useQuery } from '@tanstack/react-query';
+import instance from '../axios';
+import { myActivitiesKey } from './keys';
+
+interface BaseRequest {
+  category?: string;
+  keyword?: string;
+  sort?: 'most_reviewed' | 'price_asc' | 'price_desc' | 'latest';
+}
+
+interface InfinityScrollRequest extends BaseRequest {
+  method: 'cursor';
+  cursorId: number | null;
+  size: number;
+}
+
+interface PaginationRequest extends BaseRequest {
+  method: 'offset';
+  page: number;
+  size: number;
+}
+
+type GetActivitiesRequest = InfinityScrollRequest | PaginationRequest;
+
+export interface Activity {
+  id: number;
+  userId: number;
+  title: string;
+  description: string;
+  category: string;
+  price: number;
+  address: string;
+  bannerImageUrl: string;
+  rating: number;
+  reviewCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GetActivitiesResponse {
+  cursorId: number;
+  totalCount: number;
+  activities: Activity[];
+}
+
+async function getActivities(request: GetActivitiesRequest) {
+  const params =
+    request.method === 'cursor'
+      ? {
+          method: request.method,
+          cursorId: request.cursorId,
+          size: request.size,
+        }
+      : { method: request.method, page: request.page, size: request.size };
+
+  const response = await instance.get<GetActivitiesResponse>('/my-activities', {
+    params: {
+      ...params,
+      category: request.category,
+      keyword: request.keyword,
+      sort: request.sort,
+    },
+  });
+  return response.data;
+}
+
+const useGetMyActivities = (request: GetActivitiesRequest) => {
+  return useQuery({
+    queryKey: myActivitiesKey.getActivities(
+      // request.method === 'cursor' ? request.cursorId : request.page,
+      request.size,
+      // request.category,
+      // request.keyword,
+      // request.sort,
+    ),
+    queryFn: () => getActivities(request),
+  });
+};
+
+export default useGetMyActivities;

--- a/apis/my-activitie-reservation-status/useGetMyReservationStatus.ts
+++ b/apis/my-activitie-reservation-status/useGetMyReservationStatus.ts
@@ -1,0 +1,45 @@
+import { useQuery } from '@tanstack/react-query';
+import instance from '../axios';
+import { reservationsKey } from './keys';
+
+interface MyReservations {
+  activity: {
+    id: number;
+    title: string;
+    bannerImageUrl: string;
+  };
+  scheduleId: number;
+  id: number;
+  teamId: string;
+  userId: number;
+  status: string;
+  reviewSubmitted: boolean;
+  totalPrice: number;
+  headCount: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface GetMyReservationsResponse {
+  totalCount: number;
+  reservations: MyReservations[];
+}
+
+async function getMyReservations(): Promise<GetMyReservationsResponse> {
+  const response = await instance.get<GetMyReservationsResponse>(
+    '/my-reservations?size=10000',
+  );
+  return response.data;
+}
+
+const useGetMyReservationStatus = () => {
+  return useQuery<GetMyReservationsResponse>({
+    queryKey: reservationsKey.getMyReservations(), // key 생성 시 기본 값으로 설정
+    queryFn: getMyReservations,
+  });
+};
+
+export default useGetMyReservationStatus;

--- a/apis/my-activitie-reservation-status/useGetReservationDashboard.ts
+++ b/apis/my-activitie-reservation-status/useGetReservationDashboard.ts
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query'; //
+import instance from '../axios';
+import { myReservationStatusKey } from './keys';
+
+interface BaseRequest {
+  activityId: number | undefined;
+  year: string;
+  month: string;
+}
+
+interface reservationsStatusCount {
+  completed: number;
+  confirmed: number;
+  pending: number;
+}
+
+export interface dayOfReservation {
+  date: string;
+  reservations: reservationsStatusCount;
+}
+
+async function getMyReservationStatus(request: BaseRequest) {
+  const response = await instance.get<dayOfReservation[]>(
+    '/my-activities/' + request.activityId + '/reservation-dashboard',
+    {
+      params: {
+        activityId: request.activityId,
+        year: request.year,
+        month: request.month,
+      },
+    },
+  );
+  return response.data;
+}
+
+const useGetReservationDashboard = (request: BaseRequest) => {
+  return useQuery({
+    queryKey: myReservationStatusKey.getMyReservationStatus(
+      request.activityId,
+      request.year,
+      request.month,
+    ),
+    queryFn: () => getMyReservationStatus(request),
+  });
+};
+
+export default useGetReservationDashboard;

--- a/apis/my-activitie-reservation-status/useGetReservedSchedule.ts
+++ b/apis/my-activitie-reservation-status/useGetReservedSchedule.ts
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query'; //
+import instance from '../axios';
+import { reservedScheduleKey } from './keys';
+
+interface BaseRequest {
+  activityId: number | undefined;
+  date: string;
+}
+
+interface reservationsStatusCount {
+  confirmed: number;
+  pending: number;
+  declined: number;
+}
+
+export interface dayOfReservation {
+  scheduleId: number;
+  startTime: string;
+  endTime: string;
+  count: reservationsStatusCount;
+}
+
+async function getReservedSchedule(request: BaseRequest) {
+  const response = await instance.get<dayOfReservation[]>(
+    '/my-activities/' + request.activityId + '/reserved-schedule',
+    {
+      params: {
+        activityId: request.activityId,
+        date: request.date,
+      },
+    },
+  );
+  return response.data;
+}
+
+const useGetReservedSchedule = (request: BaseRequest) => {
+  return useQuery({
+    queryKey: reservedScheduleKey.getReservedSchedule(
+      request.activityId,
+      request.date,
+    ),
+    queryFn: () => getReservedSchedule(request),
+  });
+};
+
+export default useGetReservedSchedule;

--- a/apis/my-activitie-reservation-status/useGetReservedTime.ts
+++ b/apis/my-activitie-reservation-status/useGetReservedTime.ts
@@ -1,0 +1,60 @@
+import { useQuery } from '@tanstack/react-query'; //
+import instance from '../axios';
+import { reservedTimeKey } from './keys';
+
+interface BaseRequest {
+  activityId: number | undefined;
+  scheduleId: number | undefined;
+  status: string;
+}
+
+interface reservation {
+  id: number;
+  status: string;
+  totalPrice: number;
+  headCount: number;
+  nickname: string;
+  userId: number;
+  date: string;
+  startTime: string;
+  endTime: string;
+  createdAt: string;
+  updatedAt: string;
+  activityId: number;
+  scheduleId: number;
+  reviewSubmitted: boolean;
+  teamId: string;
+}
+
+export interface reservedTime {
+  totalCount: number;
+  cursorId: string;
+  reservations: reservation[];
+}
+
+async function getReservedTime(request: BaseRequest) {
+  const response = await instance.get<reservedTime>(
+    '/my-activities/' + request.activityId + '/reservations',
+    {
+      params: {
+        activityId: request.activityId,
+        scheduleId: request.scheduleId,
+        status: request.status,
+      },
+    },
+  );
+  return response.data;
+}
+
+const useGetReservedTime = (request: BaseRequest) => {
+  return useQuery({
+    queryKey: reservedTimeKey.getReservedTime(
+      request.activityId,
+      request.scheduleId,
+      request.status,
+    ),
+    queryFn: () => getReservedTime(request),
+  });
+};
+
+export default useGetReservedTime;

--- a/app/reservationHistory/page.tsx
+++ b/app/reservationHistory/page.tsx
@@ -21,61 +21,8 @@ export default function Page() {
   const [selectedActivityId, setSelectedActivityId] = useState<number>(0);
 
   const handleSelect = (id: number) => {
-    setSelectedActivityId(id); //선택한 체험의 id셋팅
+    setSelectedActivityId(id); //선택한 체험의 id
   };
-
-  //TODO: selectedActivityId로 월별 예약 리스트 데이터 가져오기
-  //TODO: 월별 예약 리스트 목업 데이터
-  let MonthReservations = [
-    {
-      date: '2024-06-01',
-      reservations: {
-        completed: 3,
-        confirmed: 0,
-        pending: 0,
-      },
-    },
-    {
-      date: '2024-06-13',
-      reservations: {
-        completed: 0,
-        confirmed: 0,
-        pending: 1,
-      },
-    },
-    {
-      date: '2024-06-15',
-      reservations: {
-        completed: 5,
-        confirmed: 2,
-        pending: 0,
-      },
-    },
-    {
-      date: '2024-06-18',
-      reservations: {
-        completed: 9,
-        confirmed: 10,
-        pending: 11,
-      },
-    },
-    {
-      date: '2024-06-23',
-      reservations: {
-        completed: 7,
-        confirmed: 0,
-        pending: 2,
-      },
-    },
-    {
-      date: '2024-06-27',
-      reservations: {
-        completed: 0,
-        confirmed: 3,
-        pending: 1,
-      },
-    },
-  ];
 
   return (
     <div style={{ minWidth: '350px' }} className="text-black200 bg-gray50">
@@ -87,10 +34,7 @@ export default function Page() {
           {myActivityes ? (
             <>
               <SelectBox myActivityes={myActivityes} onSelect={handleSelect} />
-              <Calendar
-                MonthReservations={MonthReservations}
-                selectedActivityId={selectedActivityId}
-              />
+              <Calendar selectedActivityId={selectedActivityId} />
             </>
           ) : (
             <div className="h-[1133px] pt-[111px] tablet:pt-[100px] mobile:pt-[80px] flex flex-col items-center">

--- a/app/reservationHistory/page.tsx
+++ b/app/reservationHistory/page.tsx
@@ -5,58 +5,18 @@ import Footer from '@/components/commons/Footer';
 import Calendar from '@/components/reservationHistory/Calendar';
 import SelectBox from '@/components/reservationHistory/SelectBox';
 import SideNavigationMenu from '@/components/commons/SideNavigationMenu';
+import useGetMyActivities from '@/apis/my-activitie-reservation-status/useGetMyActivities';
 import React, { useState } from 'react';
 
 export default function Page() {
-  //TODO: 내 체험 리스트 데이터 가져오기
-  //TODO: 내 체험 리스트 목업
-  let myActivityes = [
-    {
-      id: 1154,
-      userId: 409,
-      title: '길다길어111',
-      description: '길어요',
-      category: '식음료',
-      price: 112220,
-      address: '대전 동구 판교1길 3',
-      bannerImageUrl:
-        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/4-13_346_1718181839344.jpeg',
-      rating: 0,
-      reviewCount: 0,
-      createdAt: '2024-06-12T17:44:04.519Z',
-      updatedAt: '2024-06-12T17:44:04.519Z',
-    },
-    {
-      id: 1155,
-      userId: 409,
-      title: '길다길어222',
-      description: '길어요',
-      category: '식음료',
-      price: 112220,
-      address: '대전 동구 판교1길 3',
-      bannerImageUrl:
-        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/4-13_346_1718181839344.jpeg',
-      rating: 0,
-      reviewCount: 0,
-      createdAt: '2024-06-12T17:44:04.519Z',
-      updatedAt: '2024-06-12T17:44:04.519Z',
-    },
-    {
-      id: 1156,
-      userId: 409,
-      title: '길다길어333',
-      description: '길어요',
-      category: '식음료',
-      price: 112220,
-      address: '대전 동구 판교1길 3',
-      bannerImageUrl:
-        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/globalnomad/activity_registration_image/4-13_346_1718181839344.jpeg',
-      rating: 0,
-      reviewCount: 0,
-      createdAt: '2024-06-12T17:44:04.519Z',
-      updatedAt: '2024-06-12T17:44:04.519Z',
-    },
-  ];
+  //내 체험 리스트
+  const { data, isLoading, isError } = useGetMyActivities({
+    method: 'cursor',
+    cursorId: null,
+    size: 15,
+  });
+
+  const myActivityes = data?.activities;
 
   const [selectedActivityId, setSelectedActivityId] = useState<number>(0);
 
@@ -124,7 +84,7 @@ export default function Page() {
         <SideNavigationMenu />
         <div className="w-[800px] pl-[24px] tablet:w-[429px] mobile:w-[326px] mobile:px-4 text-[32px] mb-[142px] tablet:mb-[128px]">
           <p className="w-[800px] mobile:w-full font-bold">예약 현황</p>
-          {myActivityes.length > 0 ? (
+          {myActivityes ? (
             <>
               <SelectBox myActivityes={myActivityes} onSelect={handleSelect} />
               <Calendar

--- a/components/commons/Popups/ReservationHistory/ReservationInfoModal.tsx
+++ b/components/commons/Popups/ReservationHistory/ReservationInfoModal.tsx
@@ -2,28 +2,23 @@ import Image from 'next/image';
 import React, { useEffect, useRef, useState } from 'react';
 import SelectBox from '@/components/reservationHistory/SelectBox';
 import ReservationInfo from '@/components/reservationHistory/ReservationInfo';
-import { ReservationStatusCountType } from '@/types/activitiesReservationType';
+import { ModalReservationStatusCountType } from '@/types/activitiesReservationType';
+import useGetReservedSchedule from '@/apis/my-activitie-reservation-status/useGetReservedSchedule';
+import useGetReservedTime from '@/apis/my-activitie-reservation-status/useGetReservedTime';
 
 interface Props {
   closePopup: () => void;
   selectedDate: string;
   selectedActivityId: number;
-  reservationByDay: ReservationStatusCountType;
 }
 
 const ReservationInfoModal = ({
   closePopup,
   selectedDate,
   selectedActivityId,
-  reservationByDay,
 }: Props) => {
   const [selectedScheduleId, setSelectedScheduleId] = useState(0);
-  const [statusCounts, setStatusCounts] = useState({
-    declined: 0,
-    confirmed: 0,
-    pending: 0,
-  });
-  const [selectTab, setSelectTab] = useState('신청');
+  const [selectTab, setSelectTab] = useState('pending');
 
   //YYYY년 MM월 DD일
   const handleDateFormat = () => {
@@ -34,121 +29,50 @@ const ReservationInfoModal = ({
   };
 
   // TODO : 내 체험 날짜별 예약정보(신청, 승인, 거절)이 있는 스케쥴 조회
-  ///{teamId}/my-activities/{activityId}/reserved-schedule
-  //selectBox 및 상태별 카운팅을 위한 목업 데이터
-  const dayReservations = [
-    {
-      scheduleId: 3991,
-      startTime: '4:00',
-      endTime: '5:00',
-      count: {
-        declined: 0, //거절
-        confirmed: 0, //승인
-        pending: 1, //신청
-      },
-    },
-    {
-      scheduleId: 3992,
-      startTime: '7:00',
-      endTime: '8:00',
-      count: {
-        declined: 0,
-        confirmed: 0,
-        pending: 1,
-      },
-    },
-    {
-      scheduleId: 3993,
-      startTime: '11:00',
-      endTime: '13:00',
-      count: {
-        declined: 2,
-        confirmed: 3,
-        pending: 5,
-      },
-    },
-  ];
+  const shouldFetchData = selectedActivityId !== 0;
+  const {
+    data: dayReservations,
+    isLoading: dayReservationIsLoading,
+    isError: dayReservationsIsError,
+  } = useGetReservedSchedule({
+    activityId: shouldFetchData ? selectedActivityId : undefined,
+    date: selectedDate,
+  });
 
-  useEffect(() => {
-    const totalCounts = dayReservations.reduce(
-      (acc, reservation) => {
-        acc.declined += reservation.count.declined;
-        acc.confirmed += reservation.count.confirmed;
-        acc.pending += reservation.count.pending;
-        return acc;
-      },
-      { declined: 0, confirmed: 0, pending: 0 },
-    );
-    setStatusCounts(totalCounts);
-  }, []);
+  const statusTotalCounts = dayReservations?.reduce(
+    (acc, reservation) => {
+      acc.declined += reservation.count.declined;
+      acc.confirmed += reservation.count.confirmed;
+      acc.pending += reservation.count.pending;
+      return acc;
+    },
+    { declined: 0, confirmed: 0, pending: 0 },
+  );
 
   const handleSelect = (scheduleId: number) => {
     setSelectedScheduleId(scheduleId);
   };
 
-  //TODO: select버튼을 통해 받은 selectedScheduleId로 내 체험 예약 시간대별 예약 내역 조회
-  const reservationInfos = [
-    {
-      id: 1605,
-      status: 'pending',
-      totalPrice: 112220,
-      headCount: 11,
-      nickname: '차박좋아',
-      userId: 362,
-      date: '2024-06-13',
-      startTime: '4:00',
-      endTime: '5:00',
-      createdAt: '2024-06-13T00:36:50.264Z',
-      updatedAt: '2024-06-13T00:36:50.264Z',
-      activityId: 1154,
-      scheduleId: 3991,
-      reviewSubmitted: false,
-      teamId: '4-13',
-    },
-    {
-      id: 1605,
-      status: 'pending',
-      totalPrice: 112220,
-      headCount: 5,
-      nickname: '캠핑갈래',
-      userId: 362,
-      date: '2024-06-13',
-      startTime: '4:00',
-      endTime: '5:00',
-      createdAt: '2024-06-13T00:36:50.264Z',
-      updatedAt: '2024-06-13T00:36:50.264Z',
-      activityId: 1154,
-      scheduleId: 3991,
-      reviewSubmitted: false,
-      teamId: '4-13',
-    },
-    {
-      id: 1605,
-      status: 'pending',
-      totalPrice: 112220,
-      headCount: 5,
-      nickname: '캠핑갈래!!',
-      userId: 362,
-      date: '2024-06-13',
-      startTime: '4:00',
-      endTime: '5:00',
-      createdAt: '2024-06-13T00:36:50.264Z',
-      updatedAt: '2024-06-13T00:36:50.264Z',
-      activityId: 1154,
-      scheduleId: 3991,
-      reviewSubmitted: false,
-      teamId: '4-13',
-    },
-  ];
+  // 내 체험 예약 시간대별 예약 내역 조회
+  const {
+    data: reservedTimeData,
+    isLoading: reservedTimeIsLoading,
+    isError: reservedTimeIsError,
+  } = useGetReservedTime({
+    activityId: shouldFetchData ? selectedActivityId : undefined,
+    scheduleId: selectedScheduleId,
+    status: selectTab,
+  });
 
   const selectDate = handleDateFormat();
 
   handleDateFormat();
+
   return (
     <div
       className={`w-[429px] ${
-        selectTab === '신청' ? 'h-[697px]' : 'h-[645px]'
-      } rounded-3xl border border-[#DDD] bg-white p-6 text-black200`}
+        selectTab === 'pending' ? 'h-[697px]' : 'h-[645px]'
+      } rounded-3xl border border-[#DDD] bg-white p-6 text-black200 z-20 absolute ml-[-420px]`}
     >
       <div className="h-[35px] flex justify-between items-center">
         <h1 className="text-h1 text-black200">예약 정보</h1>
@@ -161,30 +85,31 @@ const ReservationInfoModal = ({
           className="cursor-pointer"
         />
       </div>
+      {/* 예약정보 상태별 탭 */}
       <div className="flex gap-[22px] mt-8 pl-2">
         <div
           className={`text-[20px] ${
-            selectTab === '신청' && 'text-green200 font-semibold'
+            selectTab === 'pending' && 'text-green200 font-semibold'
           } cursor-pointer`}
-          onClick={() => setSelectTab('신청')}
+          onClick={() => setSelectTab('pending')}
         >
-          신청 {statusCounts.pending}
+          신청 {statusTotalCounts?.pending || 0}
         </div>
         <div
           className={`text-[20px] ${
-            selectTab === '승인' && 'text-green200 font-semibold'
+            selectTab === 'confirmed' && 'text-green200 font-semibold'
           } cursor-pointer`}
-          onClick={() => setSelectTab('승인')}
+          onClick={() => setSelectTab('confirmed')}
         >
-          승인 {statusCounts.confirmed}
+          승인 {statusTotalCounts?.confirmed || 0}
         </div>
         <div
           className={`text-[20px] ${
-            selectTab === '거절' && 'text-green200 font-semibold'
+            selectTab === 'declined' && 'text-green200 font-semibold'
           } cursor-pointer`}
-          onClick={() => setSelectTab('거절')}
+          onClick={() => setSelectTab('declined')}
         >
-          거절 {statusCounts.declined}
+          거절 {statusTotalCounts?.declined || 0}
         </div>
       </div>
       <div className="mt-3 relative">
@@ -196,36 +121,40 @@ const ReservationInfoModal = ({
         />
         <div
           className={`w-[72px] h-1 bg-green200 rounded-xl mt-[-2px] absolute ${
-            selectTab !== '신청' &&
-            (selectTab === '승인' ? 'ml-[72px]' : 'ml-[144px]')
+            selectTab !== 'pending' &&
+            (selectTab === 'confirmed' ? 'ml-[72px]' : 'ml-[144px]')
           }`}
         ></div>
       </div>
-      <div>
-        <h2 className="text-[20px] font-semibold text-black200 mt-7">
-          예약날짜
-        </h2>
-        <p className="my-4 text-[20px]">{selectDate}</p>
-        <SelectBox reservations={dayReservations} onSelect={handleSelect} />
-      </div>
-      <div className="mt-8">
-        <h2 className="text-[20px] font-semibold text-black200">예약내역</h2>
-        <div
-          className={`${
-            selectTab === '신청' && 'h-[286px] overflow-scroll'
-          } mt-4`}
-        >
-          {reservationInfos.map((reservationInfo, index) => (
-            <ReservationInfo
-              key={index}
-              selectTab={selectTab}
-              reservationInfo={reservationInfo}
-            />
-          ))}
+      {/* 예약날짜 */}
+      <div className="h-[420px]">
+        <div>
+          <h2 className="text-[20px] font-semibold text-black200 mt-7">
+            예약날짜
+          </h2>
+          <p className="my-4 text-[20px]">{selectDate}</p>
+          <SelectBox reservations={dayReservations} onSelect={handleSelect} />
+        </div>
+        {/* 예약내역 */}
+        <div className="mt-8">
+          <h2 className="text-[20px] font-semibold text-black200">예약내역</h2>
+          <div
+            className={`${
+              selectTab === 'pending' && 'h-[286px] overflow-scroll'
+            } mt-4`}
+          >
+            {reservedTimeData?.reservations.map((reservationInfo, index) => (
+              <ReservationInfo
+                key={index}
+                selectTab={selectTab}
+                reservationInfo={reservationInfo}
+              />
+            ))}
+          </div>
         </div>
       </div>
-      {selectTab !== '신청' && (
-        <div className="mt-[80px]  flex justify-between text-[24px] font-semibold font-black200">
+      {selectTab !== 'pending' && (
+        <div className="flex justify-between text-[24px] font-semibold font-black200">
           <p>예약 현황</p>
           <p>5</p>
         </div>

--- a/components/reservationHistory/Calendar.tsx
+++ b/components/reservationHistory/Calendar.tsx
@@ -16,6 +16,7 @@ const Calendar = ({ selectedActivityId }: Props) => {
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState('');
   const [isReservationModalOpen, setIsReeservationModalOpen] = useState(false);
+  const [isSeletedDay, setIsSeletedDay] = useState(0);
   const [selectedReservationDate, setSelectedReservationDate] = useState({
     completed: 0,
     confirmed: 0,
@@ -33,6 +34,7 @@ const Calendar = ({ selectedActivityId }: Props) => {
 
   const handleCloseModal = () => {
     setIsReeservationModalOpen(false);
+    setIsSeletedDay(0);
   };
 
   const getDaysInMonth = (year: number, month: number) => {
@@ -182,11 +184,19 @@ const Calendar = ({ selectedActivityId }: Props) => {
           onClick={() => {
             setSelectedDate(currentDateStr);
             setIsReeservationModalOpen(true);
+            setIsSeletedDay(day);
             setSelectedReservationDate(dayData);
           }}
         >
-          <div className="pl-3 mobile:pl-1 pt-3 mobile:pt-1 text-[21px] mobile:text-[16px] flex flex-row">
-            {day}
+          <div className="pl-3 mobile:pl-1 pt-3 mobile:pt-1 text-[21px] mobile:text-[16px] flex flex-row relative">
+            <div
+              className={`${
+                isSeletedDay === day &&
+                'w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center text-black text-[23px] mobile:text-[18px]'
+              }`}
+            >
+              {day}
+            </div>
             {(iconCompleted || iconReservation) && (
               <div className="h-10px mt-1 ml-1 w-2 h-2 relative">
                 {iconCompleted && (

--- a/components/reservationHistory/Calendar.tsx
+++ b/components/reservationHistory/Calendar.tsx
@@ -185,7 +185,6 @@ const Calendar = ({ selectedActivityId }: Props) => {
             setSelectedDate(currentDateStr);
             setIsReeservationModalOpen(true);
             setIsSeletedDay(day);
-            setSelectedReservationDate(dayData);
           }}
         >
           <div className="pl-3 mobile:pl-1 pt-3 mobile:pt-1 text-[21px] mobile:text-[16px] flex flex-row">
@@ -281,14 +280,12 @@ const Calendar = ({ selectedActivityId }: Props) => {
           closePopup={handleCloseModal}
           selectedDate={selectedDate}
           selectedActivityId={selectedActivityId}
-          reservationByDay={selectedReservationDate}
         />
       </div>
       <div
         style={{ minWidth: '326px' }}
         className="mt-6 w-full border-y border-l border-r rounded-t-lg rounded-b-lg bg-white"
       >
-        {/* <div className="mt-6 w-full border-y border-x ounded-t-lg rounded-b-lg bg-white"> */}
         {renderDays()}
         {renderCells()}
       </div>

--- a/components/reservationHistory/Calendar.tsx
+++ b/components/reservationHistory/Calendar.tsx
@@ -188,7 +188,7 @@ const Calendar = ({ selectedActivityId }: Props) => {
             setSelectedReservationDate(dayData);
           }}
         >
-          <div className="pl-3 mobile:pl-1 pt-3 mobile:pt-1 text-[21px] mobile:text-[16px] flex flex-row relative">
+          <div className="pl-3 mobile:pl-1 pt-3 mobile:pt-1 text-[21px] mobile:text-[16px] flex flex-row">
             <div
               className={`${
                 isSeletedDay === day &&

--- a/components/reservationHistory/Calendar.tsx
+++ b/components/reservationHistory/Calendar.tsx
@@ -1,18 +1,18 @@
 import Image from 'next/image';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Chips from '@/components/reservationHistory/Chips';
 import ReviewModal from '@/components/commons/Popups/ReviewModal/ReviewModal';
 import ReservationInfoModal from '@/components/commons/Popups/ReservationHistory/ReservationInfoModal';
+import useGetReservationDashboard from '@/apis/my-activitie-reservation-status/useGetReservationDashboard';
 import { ReservationDayInfoType } from '@/types/activitiesReservationType';
 
 const daysOfWeek = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
 
 interface Props {
-  MonthReservations: ReservationDayInfoType[];
   selectedActivityId: number;
 }
 
-const Calendar = ({ MonthReservations, selectedActivityId }: Props) => {
+const Calendar = ({ selectedActivityId }: Props) => {
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState('');
   const [isReservationModalOpen, setIsReeservationModalOpen] = useState(false);
@@ -20,6 +20,15 @@ const Calendar = ({ MonthReservations, selectedActivityId }: Props) => {
     completed: 0,
     confirmed: 0,
     pending: 0,
+  });
+
+  const [dashboardData, setDashboardData] = useState(null);
+  const shouldFetchData = selectedActivityId !== 0;
+
+  const { data, isLoading, isError } = useGetReservationDashboard({
+    activityId: shouldFetchData ? selectedActivityId : undefined,
+    year: '2024',
+    month: '06',
   });
 
   const handleCloseModal = () => {
@@ -150,9 +159,10 @@ const Calendar = ({ MonthReservations, selectedActivityId }: Props) => {
         pending: 0,
       };
 
-      MonthReservations.forEach((activity) => {
-        if (activity.date === currentDateStr) {
-          dayData = { ...activity.reservations };
+      //해당일에 예약이 있는 경우 값 셋팅
+      data?.forEach(({ date, reservations }) => {
+        if (date == currentDateStr) {
+          dayData = { ...reservations };
         }
       });
 
@@ -175,24 +185,22 @@ const Calendar = ({ MonthReservations, selectedActivityId }: Props) => {
             setSelectedReservationDate(dayData);
           }}
         >
-          <div className="p-3 text-[21px] flex flex-row">
+          <div className="pl-3 mobile:pl-1 pt-3 mobile:pt-1 text-[21px] mobile:text-[16px] flex flex-row">
             {day}
             {(iconCompleted || iconReservation) && (
-              <div className="h-10px mt-1 ml-1">
+              <div className="h-10px mt-1 ml-1 w-2 h-2 relative">
                 {iconCompleted && (
                   <Image
                     src="/icons/ellipse_gray.svg"
                     alt="예약 데이터 완료 표시 아이콘"
-                    width={8}
-                    height={8}
+                    fill
                   />
                 )}
                 {iconReservation && (
                   <Image
                     src="/icons/ellipse_blue.svg"
                     alt="예약 데이터 예약 표시 아이콘"
-                    width={8}
-                    height={8}
+                    fill
                   />
                 )}
               </div>

--- a/components/reservationHistory/Chips.tsx
+++ b/components/reservationHistory/Chips.tsx
@@ -36,19 +36,16 @@ const StatusChipStyle: React.FC<StatusProps> = ({ status, count }) => {
   let text = '';
 
   if (status === 'confirmed') {
-    //confirmed : 승인
     bgColor = '[#FFF4E8]';
     fontColor = '[#FF7C1D]';
     text = '승인';
   }
   if (status === 'pending') {
-    //pending : 거절
-    bgColor = '[#0085FF]';
+    bgColor = 'blue300';
     fontColor = 'white';
     text = '예약';
   }
   if (status === 'completed') {
-    //completed : 완료
     bgColor = 'gray200';
     fontColor = 'gray600';
     text = '완료';

--- a/components/reservationHistory/ReservationInfo.tsx
+++ b/components/reservationHistory/ReservationInfo.tsx
@@ -29,7 +29,7 @@ const ReservationInfo = ({ selectTab, reservationInfo }: Props) => {
         </div>
       </div>
       <div className="flex justify-end text-[16px] gap-4">
-        {selectTab === '신청' ? (
+        {selectTab === 'pending' ? (
           <>
             <Button
               width={82}
@@ -53,10 +53,14 @@ const ReservationInfo = ({ selectTab, reservationInfo }: Props) => {
               거절하기
             </Button>
           </>
-        ) : selectTab === '승인' ? (
-          <>예약승인</>
+        ) : selectTab === 'confirmed' ? (
+          <p className="w-[85px] h-[38px] bg-[#FFF4E8] text-[#FF7C1D] flex items-center justify-center rounded-3xl">
+            예약승인
+          </p>
         ) : (
-          <button>예약거절</button>
+          <p className="w-[85px] h-[38px] bg-[#FFE4E0] text-[#FF472E] flex items-center justify-center rounded-3xl">
+            예약거절
+          </p>
         )}
       </div>
     </div>

--- a/components/reservationHistory/SelectBox.tsx
+++ b/components/reservationHistory/SelectBox.tsx
@@ -53,7 +53,7 @@ const SelectBox: React.FC<SelectBoxProps> = ({
         onClick={() => setIsOpen(!isOpen)}
       >
         {myActivityes && (
-          <p className="bg-white w-[45px] px-1 text-[14px] bottom-10 absolute">
+          <p className="bg-white w-[45px] px-1 text-[14px] left-3 bottom-10 absolute">
             체험명
           </p>
         )}

--- a/components/reservationHistory/SelectBox.tsx
+++ b/components/reservationHistory/SelectBox.tsx
@@ -78,7 +78,7 @@ const SelectBox: React.FC<SelectBoxProps> = ({
           {myActivityes?.map((activity) => (
             <li
               key={activity.id}
-              className="px-4 py-2 text-[16px] cursor-pointer hover:bg-gray-200"
+              className="px-4 py-2 text-[16px] cursor-pointer hover:bg-gray-100"
               onClick={() => handleSelect(activity)}
             >
               {activity.title}


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #153

## 📝작업 내용

> 예약 현황 체험명 selectBox데이터 연결
> 체험명에 따른 캘린더 데이터 연결
> 캘린더 UI 일부 수정. 선택한 날짜에 표시 등
> 모달의 시간, 상태, 예약 내역 데이터 연결

## 📷스크린샷 (선택)
<img width="876" alt="image" src="https://github.com/GlobalNomad-FE/FE/assets/101369040/5d848921-3c8d-420c-9035-069d9ffe0972">


## 💬리뷰 요구사항(선택)

> 
