### PR TITLE
[Feat] 예약 내역 페이지 수정

### DIFF
--- a/app/my-reservations/page.tsx
+++ b/app/my-reservations/page.tsx
@@ -85,7 +85,7 @@ const MyReservations = () => {
 
   return (
     <div>
-      <main className="flex justify-center min-h-[100vh] max-h-[100%] px-6 bg-gray50 pt-[142px] pb-[72px]">
+      <main className="flex justify-center min-h-[100vh] max-h-[100%] px-6 bg-gray50 pt-[142px] pb-[72px] mobile:pt-[94px]">
         <div className="flex gap-6 w-[1200px]">
           <SideNavigationMenu />
           <div className="flex flex-col flex-grow">

--- a/app/my-reservations/page.tsx
+++ b/app/my-reservations/page.tsx
@@ -85,7 +85,7 @@ const MyReservations = () => {
 
   return (
     <div>
-      <main className="flex justify-center min-h-[100vh] max-h-[100%] px-6 bg-gray50 pt-[142px] pb-[72px] mobile:pt-[94px]">
+      <main className="flex justify-center min-h-[100vh] max-h-[100%] px-6 bg-gray50 pt-[142px] pb-[72px]">
         <div className="flex gap-6 w-[1200px]">
           <SideNavigationMenu />
           <div className="flex flex-col flex-grow">

--- a/components/commons/Popups/ReviewModal/ReviewModal.tsx
+++ b/components/commons/Popups/ReviewModal/ReviewModal.tsx
@@ -54,6 +54,7 @@ const ReviewModal = ({
 
   const handleCloseModal = () => {
     setOpenModal(false);
+    window.location.reload();
   };
 
   return (

--- a/components/commons/card/ReservationsExperience.tsx
+++ b/components/commons/card/ReservationsExperience.tsx
@@ -2,13 +2,13 @@
 import Image from 'next/image';
 import { MouseEvent, useEffect, useState } from 'react';
 import ReviewModal from '../Popups/ReviewModal/ReviewModal';
-import Menu from '@/components/activitie/Menu';
 import Button from '../Button';
 import BasePopupTwoBtns from '../Popups/BasePopupTwoBtns';
 import useMediaQuery from '@/hooks/useMediaQuery';
 import useUpdateReservationStatus from '@/apis/my-reservations/usePatchMyReservations';
 import { useRouter } from 'next/navigation';
 import { ReservationsExperienceType } from './ExperienceType';
+import { toast } from 'react-toastify';
 
 /**
  * 이미지와 함께 체험정보와 예약상태를 볼 수 있는 카드 컴포넌트 입니다.
@@ -42,11 +42,11 @@ const ReservationsExperience = ({
 
   const { mutate: updateStatus } = useUpdateReservationStatus({
     onSuccess: () => {
-      alert('취소가 완료되었습니다.');
+      toast.success('취소가 완료되었습니다.');
       setStatus('canceled');
     },
     onError: () => {
-      alert('취소에 실패했습니다.');
+      toast.error('취소에 실패했습니다.');
     },
   });
 
@@ -57,7 +57,7 @@ const ReservationsExperience = ({
   const router = useRouter();
 
   const handleOpenPopup = (e: MouseEvent) => {
-    e.preventDefault();
+    e.stopPropagation();
     setOpenPopup(true);
   };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> - 모바일 버전에서 위에 여백 수정
> - 예약 취소 버튼 눌렀을 때 페이지 이동되는 이벤트가 안막혔길래 수정했습니다.
> - 에러 메세지 지영님이 넣어주신 toast로 변경했습니다.

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
