### PR TITLE
[Feat] gnb, DropdownMenu, 알림 창 수정

### DIFF
--- a/apis/my-notifications/useGetMyNotifications.tsx
+++ b/apis/my-notifications/useGetMyNotifications.tsx
@@ -29,7 +29,6 @@ const useGetMyNotifications = () => {
   return useQuery<GetMyNotificationsResponse>({
     queryKey: notificationsKey.getMyNotifications(),
     queryFn: getMyNotifications,
-    refetchInterval: 1000, // 1초마다 데이터를 새로고침
   });
 };
 

--- a/components/commons/avatar/avatar.tsx
+++ b/components/commons/avatar/avatar.tsx
@@ -14,9 +14,9 @@ export default function Avatar({ profileImageUrl = null }: AvatarProps) {
       <Image
         src={imageUrl}
         alt="프로필 이미지"
-        className="rounded-full object-cover"
-        height={45}
-        width={45}
+        className="w-8 h-8 rounded-full object-cover"
+        height={32}
+        width={32}
       />
     </div>
   );

--- a/components/commons/dropdownMenu/DropdownMenu.tsx
+++ b/components/commons/dropdownMenu/DropdownMenu.tsx
@@ -14,7 +14,7 @@ interface DropdownMenuProps {
 export default function DropdownMenu({ dropdownMenuList }: DropdownMenuProps) {
   return (
     <div
-      className="bg-white absolute top-[72px] right-[-30px] border rounded-md text-gray600 text-body1-regular cursor-pointer"
+      className="bg-white absolute top-[72px] right-[-45px] w-[160px] border rounded-md text-gray600 text-body1-regular cursor-pointer mobile:w-[150px]"
       style={{ boxShadow: '0px 4px 8px 0px rgba(0, 0, 0, 0.08)' }}
     >
       {dropdownMenuList.map((item, index) =>
@@ -22,7 +22,7 @@ export default function DropdownMenu({ dropdownMenuList }: DropdownMenuProps) {
           <Link
             key={index}
             href={item.path}
-            className="flex gap-3 items-center h-[3.625rem] py-4 px-[22px] border-b border-gray200 text-gray600 font-medium hover:bg-gray100 mobile:h-[4.1rem] mobile:text-sm"
+            className="flex gap-3 items-center h-[3.625rem] py-4 px-[22px] border-b border-gray200 text-gray600 font-medium hover:bg-gray100 mobile:h-[3.5rem] mobile:text-sm"
           >
             <Image
               src={item.icon}
@@ -37,7 +37,7 @@ export default function DropdownMenu({ dropdownMenuList }: DropdownMenuProps) {
           <div
             key={index}
             onClick={item.handleClick}
-            className="flex gap-3 items-center h-[3.625rem] py-4 px-[22px] border-gray200 text-gray600 font-medium hover:bg-gray100 mobile:h-[4.1rem] mobile:text-sm"
+            className="flex gap-3 items-center h-[3.625rem] py-4 px-[22px] border-gray200 text-gray600 font-medium hover:bg-gray100 mobile:h-[3.5rem] mobile:text-sm"
           >
             <Image
               src={item.icon}

--- a/components/commons/gnb/gnb.tsx
+++ b/components/commons/gnb/gnb.tsx
@@ -98,15 +98,15 @@ export default function GNB() {
               <Link href="/signup">회원가입</Link>
             </div>
           ) : (
-            <div className=" flex items-center  static">
+            <div className=" flex items-center gap-[25px] static">
               <MyNotifications />
+              <div className="w-[1px] h-[22px] bg-gray200" />
               <div className=" flex relative gap-10">
-                <div className=" h-[35.2px] border-r-[1px_gray300]" />
                 <div className="flex w-fit-content gap-[16px]">
                   <button
                     onClick={isDropdownOpenToggle}
                     ref={ref}
-                    className="flex text-[16px] items-center body1-regular gap-4 text-nomad-black "
+                    className="flex text-[16px] items-center body1-regular gap-[10px] text-nomad-black "
                   >
                     <Avatar profileImageUrl={MyInfoData?.profileImageUrl} />
                     {MyInfoData?.nickname}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> - gnb 프로필 이미지 부분 수정하면서 피그마와 맞지 않는 부분 UI 살짝 수정했습니다.
> - gnb의 프로필 클릭 시 나오는 DropdownMenu를 padding 값으로 크기를 조절했더니 계속 프로필 영역 크기에 가로 사이즈가 맞춰지는 것 같아서 가로 사이즈 지정해놨습니다.
> - 알림 창 1초마다 데이터 받아오는 부분 그냥 삭제했습니다...ㅎㅎ
>   - 보니까 네이버 같은데도 알림이 오자마자 바로 뜨는게 아니라 새로 고침해야 알림이 들어오는데 굳이 실시간으로 받아올 필요가 있나 싶긴하더라구요...?

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
