### PR TITLE
[Feat] 예약현황페이지 오타 및 css수정

### DIFF
--- a/app/reservationHistory/page.tsx
+++ b/app/reservationHistory/page.tsx
@@ -26,8 +26,6 @@ export default function Page() {
 
   return (
     <>
-      {/* <div className="pt-[142px] tablet:pt-[94px] mobile:pt-[94px] w-full flex justify-center relative text-black200 bg-gray50 min-w-[350px]"> */}
-
       <main className="flex justify-center min-h-[100vh] max-h-[100%] bg-gray50 text-black200 pt-[142px] tablet:pt-[94px] mobile:pt-[94px] pb-[72px] px-6 mobile:px-4">
         <div className="w-[1200px] flex gap-6">
           <SideNavigationMenu />

--- a/app/reservationHistory/page.tsx
+++ b/app/reservationHistory/page.tsx
@@ -26,32 +26,39 @@ export default function Page() {
 
   return (
     <>
-      <div className="pt-[142px] tablet:pt-[94px] mobile:pt-[94px] w-full flex justify-center relative text-black200 bg-gray50 min-w-[350px]">
-        <SideNavigationMenu />
-        <div className="w-[800px] pl-[24px] tablet:w-[429px] mobile:w-[326px] mobile:px-4 text-[32px] mb-[142px] tablet:mb-[128px]">
-          <p className="w-[800px] mobile:w-full font-bold">예약 현황</p>
-          {myActivities ? (
-            <>
-              <SelectBox myActivities={myActivities} onSelect={handleSelect} />
-              <Calendar selectedActivityId={selectedActivityId} />
-            </>
-          ) : (
-            <div className="h-[1133px] pt-[111px] tablet:pt-[100px] mobile:pt-[80px] flex flex-col items-center">
-              <div className="w-[130px] tablet:w-[105px] mobile:w-[105px] h-[177px] tablet:h-[148px] mobile:h-[148px] overflow-hidden relative">
-                <Image
-                  src="/icons/empty.svg"
-                  alt="예약 현황 미존재를 나타내는 이미지"
-                  fill
-                  style={{ objectFit: 'cover' }}
+      {/* <div className="pt-[142px] tablet:pt-[94px] mobile:pt-[94px] w-full flex justify-center relative text-black200 bg-gray50 min-w-[350px]"> */}
+
+      <main className="flex justify-center min-h-[100vh] max-h-[100%] bg-gray50 text-black200 pt-[142px] tablet:pt-[94px] mobile:pt-[94px] pb-[72px] px-6 mobile:px-4">
+        <div className="w-[1200px] flex gap-6">
+          <SideNavigationMenu />
+          <div className="w-[791px] tablet:w-[429px] mobile:w-[326px] text-[32px] mb-[142px] tablet:mb-[128px]">
+            <p className="w-[791px] mobile:w-full font-bold">예약 현황</p>
+            {myActivities ? (
+              <>
+                <SelectBox
+                  myActivities={myActivities}
+                  onSelect={handleSelect}
                 />
+                <Calendar selectedActivityId={selectedActivityId} />
+              </>
+            ) : (
+              <div className="h-[1133px] pt-[111px] tablet:pt-[100px] mobile:pt-[80px] flex flex-col items-center">
+                <div className="w-[130px] tablet:w-[105px] mobile:w-[105px] h-[177px] tablet:h-[148px] mobile:h-[148px] overflow-hidden relative">
+                  <Image
+                    src="/icons/empty.svg"
+                    alt="예약 현황 미존재를 나타내는 이미지"
+                    fill
+                    style={{ objectFit: 'cover' }}
+                  />
+                </div>
+                <p className="font-medium text-gray500 text-[24px] pt-[50px] tablet:pt-[36px]">
+                  아직 등록한 체험이 없어요.
+                </p>
               </div>
-              <p className="font-medium text-gray500 text-[24px] pt-[50px] tablet:pt-[36px]">
-                아직 등록한 체험이 없어요.
-              </p>
-            </div>
-          )}
+            )}
+          </div>
         </div>
-      </div>
+      </main>
     </>
   );
 }

--- a/app/reservationHistory/page.tsx
+++ b/app/reservationHistory/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 import Image from 'next/image';
-import Gnb from '@/components/commons/gnb/gnb';
-import Footer from '@/components/commons/Footer';
 import Calendar from '@/components/reservationHistory/Calendar';
 import SelectBox from '@/components/reservationHistory/SelectBox';
 import SideNavigationMenu from '@/components/commons/SideNavigationMenu';
@@ -16,7 +14,7 @@ export default function Page() {
     size: 15,
   });
 
-  const myActivityes = data?.activities;
+  const myActivities = data?.activities;
 
   const [selectedActivityId, setSelectedActivityId] = useState<
     number | undefined
@@ -32,9 +30,9 @@ export default function Page() {
         <SideNavigationMenu />
         <div className="w-[800px] pl-[24px] tablet:w-[429px] mobile:w-[326px] mobile:px-4 text-[32px] mb-[142px] tablet:mb-[128px]">
           <p className="w-[800px] mobile:w-full font-bold">예약 현황</p>
-          {myActivityes ? (
+          {myActivities ? (
             <>
-              <SelectBox myActivityes={myActivityes} onSelect={handleSelect} />
+              <SelectBox myActivities={myActivities} onSelect={handleSelect} />
               <Calendar selectedActivityId={selectedActivityId} />
             </>
           ) : (

--- a/components/commons/Popups/ReservationHistory/ReservationInfoModal.tsx
+++ b/components/commons/Popups/ReservationHistory/ReservationInfoModal.tsx
@@ -105,7 +105,7 @@ const ReservationInfoModal: React.FC<Props> = ({
       ref={modalRef}
       className={`w-[429px] ${
         selectTab === 'pending' ? 'h-[697px]' : 'h-[645px]'
-      } rounded-3xl border border-[#DDD] bg-white p-6 text-black200 z-20 mobile:w-screen mobile:h-screen mobile:rounded-none mobile:border-none mobile:fixed mobile:top-0 mobile:left-0 mobile:z-50 mobile:scrollbar-hide`}
+      } rounded-3xl border border-[#DDD] bg-white p-6 text-black200 z-20 mobile:w-screen mobile:h-screen mobile:rounded-none mobile:border-none mobile:fixed mobile:top-0 mobile:left-0 mobile:z-50`}
     >
       <div className="h-[35px] flex justify-between items-center">
         <h1 className="text-h1 text-black200">예약 정보</h1>
@@ -158,7 +158,7 @@ const ReservationInfoModal: React.FC<Props> = ({
           }`}
         ></div>
       </div>
-      <div className="h-[420px] mobile:h-4/5">
+      <div className="h-[430px] mobile:h-[600px]">
         <div>
           <h2 className="text-[20px] font-semibold text-black200 mt-7">
             예약날짜
@@ -172,7 +172,11 @@ const ReservationInfoModal: React.FC<Props> = ({
         </div>
         <div className="mt-8">
           <h2 className="text-[20px] font-semibold text-black200">예약내역</h2>
-          <div className={`${showScroll && 'h-[286px] overflow-scroll'} mt-4`}>
+          <div
+            className={`${
+              showScroll && 'h-[306px] overflow-y-auto  scroll-m-2'
+            } mt-4`}
+          >
             {reservedTimeData?.reservations.map((reservationInfo, index) => (
               <ReservationInfo
                 key={index}

--- a/components/reservationHistory/Calendar.tsx
+++ b/components/reservationHistory/Calendar.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import Chips from '@/components/reservationHistory/Chips';
 import ReservationInfoModal from '@/components/commons/Popups/ReservationHistory/ReservationInfoModal';
 import useGetReservationDashboard from '@/apis/my-activity-reservation-status/useGetReservationDashboard';
@@ -13,8 +13,8 @@ interface Props {
 const Calendar = ({ selectedActivityId }: Props) => {
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState('');
-  const [isReservationModalOpen, setIsReeservationModalOpen] = useState(false);
-  const [isSeletedDay, setIsSeletedDay] = useState(0);
+  const [isReservationModalOpen, setIsReservationModalOpen] = useState(false);
+  const [isSelectedDay, setIsSelectedDay] = useState(0);
 
   const year = currentMonth.getFullYear().toString();
   const month = (currentMonth.getMonth() + 1).toString().padStart(2, '0');
@@ -27,12 +27,12 @@ const Calendar = ({ selectedActivityId }: Props) => {
       year: year,
       month: month,
     },
-    shouldFetchData,
+    shouldFetchData, //요기가 false일 때는 데이터 조회 실행이 안되도록
   );
 
   const handleCloseModal = () => {
-    setIsReeservationModalOpen(false);
-    setIsSeletedDay(0);
+    setIsReservationModalOpen(false);
+    setIsSelectedDay(0);
   };
 
   const getDaysInMonth = (year: number, month: number) => {
@@ -181,8 +181,8 @@ const Calendar = ({ selectedActivityId }: Props) => {
           key={day}
           onClick={() => {
             setSelectedDate(currentDateStr);
-            setIsReeservationModalOpen(true);
-            setIsSeletedDay(day);
+            setIsReservationModalOpen(true);
+            setIsSelectedDay(day);
           }}
         >
           <div
@@ -190,7 +190,7 @@ const Calendar = ({ selectedActivityId }: Props) => {
               day < 10 ? 'pl-[18px]' : 'pl-3'
             } mobile:pl-1 pt-3 mobile:pt-1 text-[21px] mobile:text-[16px] flex flex-row justify-between relative`}
           >
-            {isSeletedDay === day ? (
+            {isSelectedDay === day ? (
               <div className="">
                 <div className="top-[7px] left-[3px] w-11 h-11 rounded-full bg-gray-100 text-black absolute" />
                 <p className="top-[12px] absolute">{day}</p>

--- a/components/reservationHistory/Calendar.tsx
+++ b/components/reservationHistory/Calendar.tsx
@@ -283,7 +283,7 @@ const Calendar = ({ selectedActivityId }: Props) => {
         </div>
       </div>
       <div
-        className={`absolute top-1/4 ml-[370px] tablet:ml-0 mobile:top-16 mobile:ml-0 mobile:left-0 mobile:scrollbar-hide ${
+        className={`absolute top-1/4 ml-[370px] tablet:ml-0 mobile:top-16 mobile:ml-0 mobile:left-0 ${
           !isReservationModalOpen && 'hidden'
         }`}
       >

--- a/components/reservationHistory/Calendar.tsx
+++ b/components/reservationHistory/Calendar.tsx
@@ -94,11 +94,11 @@ const Calendar = ({ selectedActivityId }: Props) => {
     return (
       <div
         style={{ minWidth: '326px' }}
-        className="grid grid-cols-7 content-center justify-items-start w-[792px] tablet:w-[429px] mobile:w-[326px] h-[45px] divide-x border-b"
+        className="grid grid-cols-7 content-center justify-items-start w-[792px] tablet:w-[429px] mobile:w-[326px] h-[42px] mobile:h-[33px] divide-x border-b"
       >
         {daysOfWeek.map((day, index) => (
           <div
-            className="w-[61px] tablet:w-[61px] mobile:w-[37px] text-center font-medium text-[16px] p-3 pb-1 text-[#969696]"
+            className="w-[61px] tablet:w-[61px] mobile:w-[37px] text-center font-medium text-[16px] p-3 mobile:p-1 pb-1 text-[#969696]"
             key={index}
           >
             {day}
@@ -240,7 +240,7 @@ const Calendar = ({ selectedActivityId }: Props) => {
       cells.push(
         <div
           className={`h-[154px] tablet:h-[125px] p-3 text-gray-200 text-[21px] bg-gray-100 border-l ${
-            cells.length === 6 && 'border-r rounded-br-lg'
+            cells.length === 6 && ' rounded-br-lg'
           }`}
           key={`next-${day}`}
         >
@@ -272,7 +272,7 @@ const Calendar = ({ selectedActivityId }: Props) => {
 
   return (
     <>
-      <div className="mx-auto mt-10 w-[792px] tablet:w-[429px] mobile:w-[326px] flex flex-col items-center relative">
+      <div className="mx-auto mt-10 w-[792.5px] tablet:w-[429.5px] mobile:w-[327px] flex flex-col items-center relative">
         {renderHeader()}
         <div
           style={{ minWidth: '326px' }}

--- a/components/reservationHistory/SelectBox.tsx
+++ b/components/reservationHistory/SelectBox.tsx
@@ -67,7 +67,7 @@ const SelectBox: React.FC<SelectBoxProps> = ({
       ref={selectBoxRef}
       className={`relative ${
         myActivities
-          ? 'w-[800px] tablet:w-[429px] mobile:w-[326px] mt-[42px]'
+          ? 'w-[791px] tablet:w-[429px] mobile:w-[326px] mt-[42px]'
           : 'w-[381px] tablet:w-[381px] mobile:w-[303px] rounded-2xl '
       } h-[48px]`}
     >

--- a/components/reservationHistory/SelectBox.tsx
+++ b/components/reservationHistory/SelectBox.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import React, { useEffect, useRef, useState } from 'react';
-import { Activity, MyActivitieType } from '@/types/myActivitiesType';
+import { Activity } from '@/types/myActivitiesType';
 import {
   ReservationScheduleType,
   ReservationStatusCountType,
@@ -8,14 +8,14 @@ import {
 
 interface SelectBoxProps {
   selectedDate?: string;
-  myActivityes?: Activity[];
+  myActivities?: Activity[];
   reservations?: ReservationScheduleType[];
   onSelect: (id: number) => void;
 }
 
 const SelectBox: React.FC<SelectBoxProps> = ({
   selectedDate,
-  myActivityes,
+  myActivities,
   reservations,
   onSelect,
 }) => {
@@ -66,7 +66,7 @@ const SelectBox: React.FC<SelectBoxProps> = ({
     <div
       ref={selectBoxRef}
       className={`relative ${
-        myActivityes
+        myActivities
           ? 'w-[800px] tablet:w-[429px] mobile:w-[326px] mt-[42px]'
           : 'w-[381px] tablet:w-[381px] mobile:w-[303px] rounded-2xl '
       } h-[48px]`}
@@ -77,13 +77,13 @@ const SelectBox: React.FC<SelectBoxProps> = ({
         } rounded-[4px] bg-white flex justify-between cursor-pointer`}
         onClick={() => setIsOpen(!isOpen)}
       >
-        {myActivityes && (
+        {myActivities && (
           <p className="bg-white w-[45px] px-1 text-[14px] left-3 bottom-10 absolute">
             체험명
           </p>
         )}
         <p className="text-[16px]">
-          {myActivityes
+          {myActivities
             ? selectActivity
               ? selectActivity.title
               : '체험을 선택하세요'
@@ -100,7 +100,7 @@ const SelectBox: React.FC<SelectBoxProps> = ({
       </div>
       {isOpen && (
         <ul className="absolute z-10 w-full bg-white border border-gray500 rounded-[4px] mt-1 max-h-60 overflow-auto">
-          {myActivityes?.map((activity) => (
+          {myActivities?.map((activity) => (
             <li
               key={activity.id}
               className="px-4 py-2 text-[16px] cursor-pointer hover:bg-gray-100"

--- a/types/myActivitiesType.ts
+++ b/types/myActivitiesType.ts
@@ -19,6 +19,6 @@ export interface Activity {
 /**
  * 내 체험 리스트
  */
-export interface MyActivitieType {
+export interface MyActivityType {
   activities: Activity[];
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #182 

## 📝작업 내용

> 다른 화면과 레이아웃 다른 부분 수정
> 오탈자 수정
> 캘린더 셀렉트박스 틀어진 부분 수정
> 모달창 내 예약내역 데이터가 여러개인 경우 세로 스크롤만 보이도록 수정

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)


