### PR TITLE
[Feat] 예약 내역 모달 내 승인, 거절 시 캘린더와 모달의 데이터를 다시 불러오도록 수정

### DIFF
--- a/apis/my-activity-reservation-status/keys.ts
+++ b/apis/my-activity-reservation-status/keys.ts
@@ -29,6 +29,7 @@ export const reservedScheduleKey = {
     date,
   ],
 };
+
 export const reservedTimeKey = {
   getReservedTime: (
     activityId: number | undefined,

--- a/apis/my-activity-reservation-status/usePatchReservationRequest.ts
+++ b/apis/my-activity-reservation-status/usePatchReservationRequest.ts
@@ -25,7 +25,6 @@ async function updateReservationStatus({
 const usePatchReservationRequest = () => {
   const { mutate } = useMutation({
     mutationFn: (request: Request) => updateReservationStatus(request),
-    onError: (error: AxiosError) => {},
   });
 
   return { mutate };

--- a/components/reservationHistory/ReservationInfo.tsx
+++ b/components/reservationHistory/ReservationInfo.tsx
@@ -1,7 +1,8 @@
-import Button from '@/components/commons/Button';
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ReservationInfoType } from '@/types/activitiesReservationType';
 import useUpdateReservationRequest from '@/apis/my-activity-reservation-status/usePatchReservationRequest';
-import { useState } from 'react';
+import Button from '@/components/commons/Button';
 import BasePopup from '@/components/commons/Popups/BasePopup';
 
 interface Props {
@@ -20,6 +21,7 @@ const ReservationInfo = ({ selectTab, reservationInfo }: Props) => {
     activityId,
     id: reservationId,
   } = reservationInfo;
+  const queryClient = useQueryClient();
   const { mutate } = useUpdateReservationRequest();
   const [openPopup, setOpenPopup] = useState(false);
   const [popupMessage, setPopupMessage] = useState('');
@@ -40,6 +42,7 @@ const ReservationInfo = ({ selectTab, reservationInfo }: Props) => {
             : setPopupMessage('거절되었습니다.');
           setOpenPopup(true);
           setIsUpdate(true);
+          queryClient.invalidateQueries();
         },
         onError: (error: any) => {
           setIsUpdate(false);


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #198 

## 📝작업 내용

> 예약 내역 모달 내 승인, 거절 시 캘린더와 모달의 데이터를 다시 불러오도록 수정

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)

